### PR TITLE
Don't clear old storage data past stale block lag.

### DIFF
--- a/contracts/libraries/History.sol
+++ b/contracts/libraries/History.sol
@@ -174,7 +174,7 @@ library History {
     /// @param blocknumber The blocknumber we want to load the historical state of
     /// @param staleBlock A block number which we can [but are not obligated to] delete history older than
     /// @return The found data
-    function findAndClear(
+    function findAndUpdate(
         HistoricalBalances memory wrapper,
         address who,
         uint256 blocknumber,

--- a/contracts/mocks/MockHistoryTracker.sol
+++ b/contracts/mocks/MockHistoryTracker.sol
@@ -57,12 +57,12 @@ contract MockHistoryTracker {
         return balances.find(_presetUser, which);
     }
 
-    function findAndClear(uint256 which, uint256 stale)
+    function findAndUpdate(uint256 which, uint256 stale)
         external
         returns (uint256)
     {
         History.HistoricalBalances memory balances = History.load("balances");
-        return balances.findAndClear(_presetUser, which, stale);
+        return balances.findAndUpdate(_presetUser, which, stale);
     }
 
     function loadBounds() external view returns (uint256, uint256) {

--- a/contracts/vaults/LockingVault.sol
+++ b/contracts/vaults/LockingVault.sol
@@ -54,7 +54,7 @@ abstract contract AbstractLockingVault is IVotingVault, ILockingVault {
 
     /// @notice Returns the historical voting power tracker
     /// @return A struct which can push to and find items in block indexed storage
-    function _votingPower()
+    t
         internal
         pure
         returns (History.HistoricalBalances memory)
@@ -77,7 +77,7 @@ abstract contract AbstractLockingVault is IVotingVault, ILockingVault {
         History.HistoricalBalances memory votingPower = _votingPower();
         // Find the historical data and clear everything more than 'staleBlockLag' into the past
         return
-            votingPower.findAndClear(
+            votingPower.findAndUpdate(
                 user,
                 blockNumber,
                 block.number - staleBlockLag

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -406,7 +406,7 @@ abstract contract AbstractVestingVault is IVotingVault {
         History.HistoricalBalances memory votingPower = _votingPower();
         // Find the historical data and clear everything more than 'staleBlockLag' into the past
         return
-            votingPower.findAndClear(
+            votingPower.findAndUpdate(
                 user,
                 blockNumber,
                 block.number - staleBlockLag

--- a/test/historicalTracking.ts
+++ b/test/historicalTracking.ts
@@ -317,7 +317,7 @@ describe("Historical data tracker", function () {
     Array.from(Array(99).keys()).forEach((i) => {
       it(`clears safely ${i}th trial `, async () => {
         const staleBlock = BigNumber.from(blockNumbers[i]).add(1);
-        historicalTracker.findAndClear(
+        historicalTracker.findAndUpdate(
           BigNumber.from(blockNumbers[i]).add(1),
           staleBlock
         );
@@ -359,7 +359,7 @@ describe("Historical data tracker", function () {
     });
     it("Leaves one when asked to clear everything", async () => {
       const staleBlock = BigNumber.from(blockNumbers[99]).add(1);
-      historicalTracker.findAndClear(
+      historicalTracker.findAndUpdate(
         BigNumber.from(blockNumbers[99]).add(1),
         staleBlock
       );


### PR DESCRIPTION
Removes the `_clear()` part of `findAndClear()` from History.sol.  Clearing storage used to grant a gas savings cost, but that is no longer the case and so should be removed to prevent Out of Gas errors if there are many changes to History.